### PR TITLE
Added Verified Labels to Stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           repo-token: ${{ secrets.token }}
           stale-issue-label: 'stale'
-          exempt-issue-labels: pinned,security,long running,discussion,vision
+          exempt-issue-labels: pinned,security,long running,discussion,vision,pending-review,verified
           stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions.'
           close-issue-message: 'This issue has been closed as no further activity has occurred.'
           days-before-issue-stale: ${{ inputs.days-before-issue-stale }}


### PR DESCRIPTION
## :recycle: Current situation

Some stale labels from verified would not be looked at

## :bulb: Proposed solution

Add `pending-review` and `verified` labels to exempt labels

## :gear: Release Notes

Stale will ignore `pending-review` and `verified` labels

## :heavy_plus_sign: Additional Information
*If applicable, provide additional context in this section.*

### Testing

--

### Reviewer Nudging

Review Stale History of [Verified Repo](https://github.com/homebridge/verified/commit/bb2fc9428801ab4348df0d2cf479227d1cec96e9#diff-b5e0854ed0838024d5cc25b4e030922e34648b9ea8c432807e35495fb805b894)