### PR TITLE
Add version outputs to npm-publish

### DIFF
--- a/.github/npm-version-script.js
+++ b/.github/npm-version-script.js
@@ -33,7 +33,8 @@ function getTagVersionFromNpm(tag) {
     return child_process.execSync(`npm info ${packageJSON.name} version --tag="${tag}"`).toString("utf8").trim();
   } catch (e) {
     console.error(`Failed to query the npm registry for the latest version for tag: ${tag}`);
-    throw e;
+    // throw e;
+    return "0.0.0";
   }
 }
 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -35,6 +35,10 @@ on:
       npm_auth_token:
         description: 'The npm access token used to publish the package'
         required: true
+    outputs:
+      NPM_VERSION:
+        value: ${{ jobs.publish_npm.outputs.NPM_VERSION }}
+
 
 jobs:
   publish_npm:
@@ -53,7 +57,7 @@ jobs:
 
       - name: Fetch Adjust version script
         if: ${{ inputs.dynamically_adjust_version }}
-        run: wget https://raw.githubusercontent.com/homebridge/.github/latest/.github/npm-version-script.js
+        run: wget -q https://raw.githubusercontent.com/homebridge/.github/latest/.github/npm-version-script.js
         working-directory: .github
 
       - name: Adjust version
@@ -79,3 +83,10 @@ jobs:
         run: npm publish --access public --tag=${{ inputs.tag }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.npm_auth_token }}
+
+      - name: Return NPM Package Version
+        id: package-version
+        uses: martinbeentjes/npm-get-version-action@v1.3.1
+
+    outputs:
+      NPM_VERSION: ${{ steps.package-version.outputs.current-version }}


### PR DESCRIPTION
These changes do the following

1 - Outputs the npm version from npm-publish, so that further steps in the GitHub actions can leverage them.

2 - Fix a bug in npm-version-script, that caused it to fail if a beta tag did not already existing on the repo.


Example usage of the outputs ( this one creates a GitHub release with the tag matching the npm version )

```
  publish_prod_release:
    needs: [get_tags, create_documentation]
    name: Publish Release Version
    if: ${{ needs.get_tags.outputs.BRANCH_NAME == 'main' }}
    uses: homebridge/.github/.github/workflows/npm-publish.yml@latest
    with:
      install_cmd: npm ci
    secrets:
      npm_auth_token: ${{ secrets.npm_token }}

  publish_github_release:
    needs: [publish_prod_release]
    runs-on: ubuntu-latest
    steps:
    - uses: actions/checkout@v4
    - name: Create Release
      uses: softprops/action-gh-release@v1
      env:
        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
      with:
        tag_name: ${{ needs.publish_prod_release.outputs.NPM_VERSION }}
        name: Release ${{ needs.publish_prod_release.outputs.NPM_VERSION }}
        generate_release_notes: true
        draft: false
        prerelease: false
```