### PR TITLE
Add provenance to npm releases

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -43,6 +43,8 @@ on:
 jobs:
   publish_npm:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
 
     steps:
       - uses: actions/checkout@v4
@@ -74,13 +76,13 @@ jobs:
 
       - name: publish (without tag)
         if: ${{ inputs.tag == null }}
-        run: npm publish --access public
+        run: npm publish --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.npm_auth_token }}
 
       - name: publish (with tag)
         if: ${{ inputs.tag != null }}
-        run: npm publish --access public --tag=${{ inputs.tag }}
+        run: npm publish --access public --tag=${{ inputs.tag }} --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.npm_auth_token }}
 


### PR DESCRIPTION
## :recycle: Current situation

Currently there are no provenance statements when publishing npm packages.

## :bulb: Proposed solution


Generate provenance statements when publishing npm packages.

## :gear: Release Notes

## :heavy_plus_sign: Additional Information

https://docs.npmjs.com/generating-provenance-statements

### Testing


I have not touched any tests.

### Reviewer Nudging

