### PR TITLE
fix: npm-version-script.js for concurrent tags on different versions

### DIFF
--- a/.github/npm-version-script-esm.js
+++ b/.github/npm-version-script-esm.js
@@ -19,7 +19,7 @@ const packageJSON = JSON.parse(fs.readFileSync('package.json', 'utf8'))
 const refArgument = process.argv[2]
 const tagArgument = process.argv[3] || 'latest'
 
-if (refArgument === null) {
+if (!refArgument) {
   console.error('ref argument is missing')
   console.error('Usage: npm-version-script-esm.js <ref> [tag]')
   process.exit(1)

--- a/.github/npm-version-script-esm.js
+++ b/.github/npm-version-script-esm.js
@@ -9,8 +9,6 @@ import child_process from 'node:child_process'
 import fs from 'node:fs'
 import process from 'node:process'
 
-import semver from 'semver'
-
 const BRANCH_VERSION_PATTERN = /^([A-Z]+)-(\d+\.\d+\.\d+)$/i
 
 // Load the contents of the package.json file
@@ -26,17 +24,22 @@ if (!refArgument) {
 }
 
 /**
- * Queries the NPM registry for the latest version for the provided tag.
- * @param tag The tag to query for.
- * @returns {string} Returns the version.
+ * Queries the NPM registry for the latest version for the provided base version and tag.
+ * If the tag is latest, then the base version is returned if it exists. For other tags, the latest
+ * version found for that base version and tag is returned.
+ * @param baseVersion The base version to query for, e.g. 2.0.0
+ * @param tag The tag to query for, e.g. beta or latest
+ * @returns {string} Returns the version, or '' if not found
  */
-function getTagVersionFromNpm(tag) {
+function getTagVersionFromNpm(baseVersion, tag) {
   try {
-    return child_process.execSync(`npm info ${packageJSON.name} version --tag="${tag}"`).toString('utf8').trim()
+    return JSON.parse(child_process.execSync(`npm info ${packageJSON.name} versions --json`).toString('utf8').trim())
+      .filter(v => tag === 'latest' ? v === baseVersion : v.startsWith(`${baseVersion}-${tag}.`)) // find all published versions for this base version and tag
+      .reduce((_, current) => current, '') // choose the last as they're sorted in ascending order, or '' if there are none
   } catch (e) {
-    console.error(`Failed to query the npm registry for the latest version for tag: ${tag}`)
+    console.error(`Failed to query the npm registry for the latest version for tag: ${tag}`, e)
     // throw e;
-    return '0.0.0'
+    return ''
   }
 }
 
@@ -65,21 +68,30 @@ function desiredTargetVersion(ref) {
 const baseVersion = desiredTargetVersion(refArgument)
 
 // query the npm registry for the latest version of the provided tag name
-const latestReleasedVersion = getTagVersionFromNpm(tagArgument) // e.g. 0.7.0-beta.12
-const latestReleaseBase = semver.inc(latestReleasedVersion, 'patch') // will produce 0.7.0 (removing the preid, needed for the equality check below)
+const latestReleasedVersion = getTagVersionFromNpm(baseVersion, tagArgument) // e.g. 0.7.0-beta.12
 
 let publishTag
-if (semver.eq(baseVersion, latestReleaseBase)) { // check if we are releasing another version for the latest beta or alpha
-  publishTag = latestReleasedVersion // set the current latest beta or alpha to be incremented
+
+if (latestReleasedVersion) {
+  console.log(`Latest published version for ${baseVersion} with tag ${tagArgument} is ${latestReleasedVersion}`)
+  publishTag = latestReleasedVersion // set this released beta or alpha to be incremented
 } else {
-  publishTag = baseVersion // start of with a new beta or alpha version
+  console.log(`No published versions for ${baseVersion} with tag ${tagArgument}`)
+  publishTag = baseVersion // start off with a new beta or alpha version
 }
 
-// save the package.json
-packageJSON.version = publishTag
-fs.writeFileSync('package.json', JSON.stringify(packageJSON, null, 2))
+if (packageJSON.version !== publishTag) {
+  // report the change for CI
+  console.log(`Changing version in package.json from ${packageJSON.version} to ${publishTag}`)
 
-// perform the same change to the package-lock.json
-const packageLockJSON = JSON.parse(fs.readFileSync('package-lock.json', 'utf8'))
-packageLockJSON.version = publishTag
-fs.writeFileSync('package-lock.json', JSON.stringify(packageLockJSON, null, 2))
+  // save the package.json
+  packageJSON.version = publishTag
+  fs.writeFileSync('package.json', JSON.stringify(packageJSON, null, 2))
+
+  // perform the same change to the package-lock.json
+  const packageLockJSON = JSON.parse(fs.readFileSync('package-lock.json', 'utf8'))
+  packageLockJSON.version = publishTag
+  fs.writeFileSync('package-lock.json', JSON.stringify(packageLockJSON, null, 2))
+} else {
+  console.log(`Leaving version in package.json at ${packageJSON.version}`)
+}

--- a/.github/npm-version-script.js
+++ b/.github/npm-version-script.js
@@ -9,8 +9,6 @@ const child_process = require('node:child_process')
 const fs = require('node:fs')
 const process = require('node:process')
 
-const semver = require('semver')
-
 const BRANCH_VERSION_PATTERN = /^([A-Z]+)-(\d+\.\d+\.\d+)$/i
 
 // Load the contents of the package.json file
@@ -26,17 +24,22 @@ if (!refArgument) {
 }
 
 /**
- * Queries the NPM registry for the latest version for the provided tag.
- * @param tag The tag to query for.
- * @returns {string} Returns the version.
+ * Queries the NPM registry for the latest version for the provided base version and tag.
+ * If the tag is latest, then the base version is returned if it exists. For other tags, the latest
+ * version found for that base version and tag is returned.
+ * @param baseVersion The base version to query for, e.g. 2.0.0
+ * @param tag The tag to query for, e.g. beta or latest
+ * @returns {string} Returns the version, or '' if not found
  */
-function getTagVersionFromNpm(tag) {
+function getTagVersionFromNpm(baseVersion, tag) {
   try {
-    return child_process.execSync(`npm info ${packageJSON.name} version --tag="${tag}"`).toString('utf8').trim()
+    return JSON.parse(child_process.execSync(`npm info ${packageJSON.name} versions --json`).toString('utf8').trim())
+      .filter(v => tag === 'latest' ? v === baseVersion : v.startsWith(`${baseVersion}-${tag}.`)) // find all published versions for this base version and tag
+      .reduce((_, current) => current, '') // choose the last as they're sorted in ascending order, or '' if there are none
   } catch (e) {
-    console.error(`Failed to query the npm registry for the latest version for tag: ${tag}`)
+    console.error(`Failed to query the npm registry for the latest version for tag: ${tag}`, e)
     // throw e;
-    return '0.0.0'
+    return ''
   }
 }
 
@@ -65,21 +68,30 @@ function desiredTargetVersion(ref) {
 const baseVersion = desiredTargetVersion(refArgument)
 
 // query the npm registry for the latest version of the provided tag name
-const latestReleasedVersion = getTagVersionFromNpm(tagArgument) // e.g. 0.7.0-beta.12
-const latestReleaseBase = semver.inc(latestReleasedVersion, 'patch') // will produce 0.7.0 (removing the preid, needed for the equality check below)
+const latestReleasedVersion = getTagVersionFromNpm(baseVersion, tagArgument) // e.g. 0.7.0-beta.12
 
 let publishTag
-if (semver.eq(baseVersion, latestReleaseBase)) { // check if we are releasing another version for the latest beta or alpha
-  publishTag = latestReleasedVersion // set the current latest beta or alpha to be incremented
+
+if (latestReleasedVersion) {
+  console.log(`Latest published version for ${baseVersion} with tag ${tagArgument} is ${latestReleasedVersion}`)
+  publishTag = latestReleasedVersion // set this released beta or alpha to be incremented
 } else {
-  publishTag = baseVersion // start of with a new beta or alpha version
+  console.log(`No published versions for ${baseVersion} with tag ${tagArgument}`)
+  publishTag = baseVersion // start off with a new beta or alpha version
 }
 
-// save the package.json
-packageJSON.version = publishTag
-fs.writeFileSync('package.json', JSON.stringify(packageJSON, null, 2))
+if (packageJSON.version !== publishTag) {
+  // report the change for CI
+  console.log(`Changing version in package.json from ${packageJSON.version} to ${publishTag}`)
 
-// perform the same change to the package-lock.json
-const packageLockJSON = JSON.parse(fs.readFileSync('package-lock.json', 'utf8'))
-packageLockJSON.version = publishTag
-fs.writeFileSync('package-lock.json', JSON.stringify(packageLockJSON, null, 2))
+  // save the package.json
+  packageJSON.version = publishTag
+  fs.writeFileSync('package.json', JSON.stringify(packageJSON, null, 2))
+
+  // perform the same change to the package-lock.json
+  const packageLockJSON = JSON.parse(fs.readFileSync('package-lock.json', 'utf8'))
+  packageLockJSON.version = publishTag
+  fs.writeFileSync('package-lock.json', JSON.stringify(packageLockJSON, null, 2))
+} else {
+  console.log(`Leaving version in package.json at ${packageJSON.version}`)
+}

--- a/.github/npm-version-script.js
+++ b/.github/npm-version-script.js
@@ -19,7 +19,7 @@ const packageJSON = JSON.parse(fs.readFileSync('package.json', 'utf8'))
 const refArgument = process.argv[2]
 const tagArgument = process.argv[3] || 'latest'
 
-if (refArgument == null) {
+if (!refArgument) {
   console.error('ref argument is missing')
   console.error('Usage: npm-version-script.js <ref> [tag]')
   process.exit(1)

--- a/.github/npm-version-script.js
+++ b/.github/npm-version-script.js
@@ -53,7 +53,7 @@ function desiredTargetVersion(ref) {
   const branchName = ref.slice('refs/heads/'.length)
 
   const results = branchName.match(BRANCH_VERSION_PATTERN)
-  if (results != null) {
+  if (results !== null) {
     if (results[1] !== tagArgument) {
       console.warn(`The base branch name (${results[1]}) differs from the tag name ${tagArgument}`)
     }


### PR DESCRIPTION
## :recycle: Current situation

Currently if you publish `2.0.0-beta.0` and then `1.5.2-beta.1`, and now we try to publish the `beta-2.0.0` branch… The `npm-version-script.js` script will only find the latest beta `1.5.2-beta.1` which does not match the `2.0.0` of the branch and would therefore change the package version to `2.0.0`. However because `2.0.0-beta.0` has already been published, it _should_ have set the package version to `2.0.0-beta.0`.

## :bulb: Proposed solution

This PR changes the `npm-version-script.js` script to find the latest published version for the version matching the branch name, and the tag specified. So it will find `2.0.0-beta.0` if publishing `beta-2.0.0` or it will find `1.5.2-beta.1` if publishing `beta-1.5.2`.

I also added more logging so it is possible to see what the script is doing in the CI output.

## :gear: Release Notes

Fixed fault when there are existing published packages of the current version and tag, but the latest published package with the tag is not the current version.

### Reviewer Nudging

For testing I copied the `npm-version-script-esm.js` into the `homebridge-roomba2` plugin and then ran tests like:

```shell
node npm-version-script-esm.js refs/heads/beta-2.0.0 beta
Latest published version for 2.0.0 with tag beta is 2.0.0-beta.0
Changing version in package.json from 1.5.2-beta.1 to 2.0.0-beta.0

node npm-version-script-esm.js refs/heads/beta-1.5.2 beta
Latest published version for 1.5.2 with tag beta is 1.5.2-beta.1
Changing version in package.json from 2.0.0-beta.0 to 1.5.2-beta.1

node npm-version-script-esm.js refs/heads/beta-1.5.2     
The base branch name (beta) differs from the tag name latest
Latest published version for 1.5.2 with tag latest is 1.5.2
Changing version in package.json from 1.5.2-beta.1 to 1.5.2

node npm-version-script-esm.js refs/heads/beta-1.5.3
The base branch name (beta) differs from the tag name latest
No published versions for 1.5.3 with tag latest
Changing version in package.json from 1.5.2 to 1.5.3

node npm-version-script-esm.js refs/heads/beta-2.0.0 alpha
The base branch name (beta) differs from the tag name alpha
No published versions for 2.0.0 with tag alpha
Changing version in package.json from 1.5.3 to 2.0.0
```
