### PR TITLE
chore(github): update the shared workflow actions to their current majors

### DIFF
--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -18,12 +18,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 20
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/determine-release-type.yml
+++ b/.github/workflows/determine-release-type.yml
@@ -25,7 +25,7 @@ jobs:
       release_type: ${{ steps.set-vars.outputs.release_type }}
       is_esm: ${{ steps.detect-esm.outputs.is_esm }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       # Set branch name & release type
       - name: Set release type

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -20,8 +20,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ inputs.node_version }}
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/homebridge-beta-bot.yml
+++ b/.github/workflows/homebridge-beta-bot.yml
@@ -45,11 +45,11 @@ jobs:
       user_email: ${{ steps.load-config.outputs.user_email }}
       dirs_length: ${{ steps.load-config.outputs.dirs_length }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 'latest'
       - name: Install jq

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -22,6 +22,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/labeler@v6
+      - uses: actions/labeler@v7
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint-docs.yml
+++ b/.github/workflows/lint-docs.yml
@@ -15,8 +15,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ inputs.node_version }}
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/nodejs-build-and-test.yml
+++ b/.github/workflows/nodejs-build-and-test.yml
@@ -38,8 +38,8 @@ jobs:
     runs-on: ${{ inputs.runs_on }}
 
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node_version }}
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/npm-publish-esm-oidc.yml
+++ b/.github/workflows/npm-publish-esm-oidc.yml
@@ -42,8 +42,8 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ inputs.node_version }}
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/npm-publish-esm.yml
+++ b/.github/workflows/npm-publish-esm.yml
@@ -46,8 +46,8 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ inputs.node_version }}
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/npm-publish-oidc.yml
+++ b/.github/workflows/npm-publish-oidc.yml
@@ -42,8 +42,8 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ inputs.node_version }}
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -46,8 +46,8 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ inputs.node_version }}
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Create New Github Beta Pre Release
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Create nightly release
         id: create_release
         uses: viperproject/create-nightly-release@v2

--- a/.github/workflows/promote-branch.yml
+++ b/.github/workflows/promote-branch.yml
@@ -17,7 +17,7 @@ jobs:
   promote:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -58,7 +58,7 @@ jobs:
       # 4️⃣ Create the promotion PR
       - name: Promote via PR
         if: ${{ steps.target.outputs.branch != 'skip' }}
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           base: ${{ steps.target.outputs.branch }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -40,7 +40,7 @@ jobs:
       release_version: ${{ steps.ensure-version.outputs.NPM_VERSION }}
       NPM_VERSION: ${{ steps.ensure-publishable-version.outputs.NPM_VERSION }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       # Download package.json and package-lock.json from previous job
 
@@ -139,8 +139,8 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -11,6 +11,8 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v6
-        env:
-          GITHUB_TOKEN: ${{ secrets.token }}
+      - uses: release-drafter/release-drafter@v7
+        with:
+          # v7 introduced a `token` input, which replaces the GITHUB_TOKEN env
+          # var the action previously read.
+          token: ${{ secrets.token }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -30,7 +30,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@v11
         with:
           repo-token: ${{ secrets.token }}
           stale-issue-label: stale

--- a/.github/workflows/sync-github-release.yml
+++ b/.github/workflows/sync-github-release.yml
@@ -30,7 +30,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Extract release notes for version
         id: extract

--- a/.github/workflows/update-beta-version.yml
+++ b/.github/workflows/update-beta-version.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
@@ -35,7 +35,7 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 'lts/*'
 

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -28,7 +28,7 @@ jobs:
     outputs:
       version: ${{ steps.final_version.outputs.version }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0 # Full history for changelog
 

--- a/sharedWorkflows/homebridge-dependency-bot.yml
+++ b/sharedWorkflows/homebridge-dependency-bot.yml
@@ -45,11 +45,11 @@ jobs:
       user_email: ${{ steps.load-config.outputs.user_email }}
       dirs_length: ${{ steps.load-config.outputs.dirs_length }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 'latest'
       - name: Install jq


### PR DESCRIPTION
Brings the actions used by the shared workflows up to their current major versions. Several were a major behind, and `create-pull-request` was two.

Worth noting: the plugin repos were already on `actions/checkout@v7` and `actions/setup-node@v7` in their own workflows, so the shared workflows had drifted *behind* the repos that call them, and the org was effectively running two versions side by side.

## What changed

| Action | From | To | Workflows |
|---|---|---|---|
| `actions/checkout` | v6 | v7 | 17 uses across 16 workflows |
| `actions/setup-node` | v6 | v7 | 10 uses across 10 workflows |
| `actions/stale` | v10 | v11 | `stale.yml` |
| `actions/labeler` | v6 | v7 | `labeler.yml` |
| `release-drafter/release-drafter` | v6 | v7 | `release-drafter.yml` |
| `peter-evans/create-pull-request` | v6 | v8 | `promote-branch.yml` |

## On the breaking changes

I read the release notes for each major rather than bumping blind:

- **stale v11** and **labeler v7** are ESM migrations plus dependency updates. No input or config changes.
- **create-pull-request v8** requires Actions Runner v2.327.1 or later **only on self-hosted runners**. Every job here runs on `ubuntu-latest`, so it does not apply — I checked, there are no self-hosted runners in this repo.
- **release-drafter v7** is the only one needing a real edit. It introduces a `token` input that replaces the `GITHUB_TOKEN` env var the action used to read, so `release-drafter.yml` now passes the secret as an input rather than an env var. Everything else about that workflow is unchanged.

Nothing else needed adjusting — no input names, defaults or behaviour changed in the rest.

## Everything already current, for completeness

`actions/upload-artifact@v7`, `actions/download-artifact@v8`, `github/codeql-action@v4`, `coverallsapp/github-action@v2`, `softprops/action-gh-release@v3`, `viperproject/create-nightly-release@v2`, `sarisia/actions-status-discord@v1`, `martinbeentjes/npm-get-version-action@v1.3.1`, `peter-evans/create-issue-from-file@v6`, `dropseed/changerelease@v1`, `TriPSs/conventional-changelog-action@v6`, `TimonVS/pr-labeler-action@v5`.

## Testing

These are reusable workflows, so the real proof is the first run of each caller. The two with the widest blast radius are `eslint.yml` and `nodejs-build-and-test.yml`, which every `@homebridge-plugins` repo now calls — those will exercise `checkout@v7` and `setup-node@v7` immediately.

The riskiest by scope is `promote-branch.yml`, since it is the least frequently run and jumps two majors. Worth a deliberate look the first time it fires.
