### PR TITLE
feat(github): add an optional changelog check to the nodejs build workflow

### DIFF
--- a/.github/workflows/nodejs-build-and-test.yml
+++ b/.github/workflows/nodejs-build-and-test.yml
@@ -100,8 +100,15 @@ jobs:
         with:
           # Tags are needed to work out what is unreleased.
           fetch-depth: 0
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
 
       - name: check changelog
+        # `runs_on` is caller-configurable, and the heredoc below is bash
+        # syntax - without this the step breaks on a Windows runner, where the
+        # default shell is PowerShell.
+        shell: bash
         env:
           CHANGELOG_PATH: ${{ inputs.changelog_path }}
         run: |

--- a/.github/workflows/nodejs-build-and-test.yml
+++ b/.github/workflows/nodejs-build-and-test.yml
@@ -125,7 +125,9 @@ jobs:
            *
            * The convention this enforces: one bullet per commit, using the exact commit
            * subject, newest at the bottom. Contributor credits may be appended as
-           * " (@user)" and are ignored when comparing.
+           * " (@user)" and are ignored when comparing. Where the same subject appears
+           * more than once - the usual cause being a cherry-pick between branches -
+           * one bullet covers them all.
            */
 
           const sh = cmd => execSync(cmd, { encoding: 'utf8' }).trim()
@@ -148,7 +150,21 @@ jobs:
             if (!raw) {
               return []
             }
-            return raw.split('\n').filter(subject => !IGNORED_SUBJECTS.some(re => re.test(subject)))
+            const seen = new Set()
+            return raw
+              .split('\n')
+              .filter(subject => !IGNORED_SUBJECTS.some(re => re.test(subject)))
+              // A fix cherry-picked onto a release branch as well as the main one
+              // shows up once per branch after they are merged. It is still a single
+              // change and wants a single bullet, so keep only the first sighting -
+              // the point at which it entered this release.
+              .filter((subject) => {
+                if (seen.has(subject)) {
+                  return false
+                }
+                seen.add(subject)
+                return true
+              })
           }
 
           function topSectionBullets(path) {

--- a/.github/workflows/nodejs-build-and-test.yml
+++ b/.github/workflows/nodejs-build-and-test.yml
@@ -22,6 +22,19 @@ on:
         default: npm ci
         required: false
         type: string
+      check_changelog:
+        description: >
+          Opt in to checking that the changelog's top section lists every
+          unreleased commit, in order, using the exact commit subjects. Off by
+          default, as not every repository follows that convention.
+        default: false
+        required: false
+        type: boolean
+      changelog_path:
+        description: Path to the changelog, when `check_changelog` is enabled.
+        default: CHANGELOG.md
+        required: false
+        type: string
     secrets:
       token:
         description: The GitHub Token which is used to push to Coveralls
@@ -72,6 +85,123 @@ jobs:
           github-token: ${{ secrets.github_token }}
           flag-name: run-${{ matrix.node_version }}
           parallel: true
+
+  # Opt-in via `check_changelog: true`. Verifies the changelog's top section
+  # lists every unreleased commit, in order, using the exact commit subjects -
+  # the mismatch is otherwise only noticed at release time, when it is most
+  # inconvenient.
+  changelog:
+    if: ${{ inputs.check_changelog }}
+
+    runs-on: ${{ inputs.runs_on }}
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # Tags are needed to work out what is unreleased.
+          fetch-depth: 0
+
+      - name: check changelog
+        env:
+          CHANGELOG_PATH: ${{ inputs.changelog_path }}
+        run: |
+          cat > /tmp/check-changelog.mjs <<'CHECK_CHANGELOG_EOF'
+          import { execSync } from 'node:child_process'
+          import { readFileSync } from 'node:fs'
+          import process from 'node:process'
+
+          /**
+           * Check that the changelog's top section lists every unreleased commit, in the
+           * order they landed.
+           *
+           * The convention this enforces: one bullet per commit, using the exact commit
+           * subject, newest at the bottom. Contributor credits may be appended as
+           * " (@user)" and are ignored when comparing.
+           */
+
+          const sh = cmd => execSync(cmd, { encoding: 'utf8' }).trim()
+
+          // Commits that legitimately have no bullet of their own. Matched on the
+          // subject rather than on which files changed: a commit that happens to touch
+          // only the changelog may still be a real change worth listing (a repo that
+          // already satisfied a sweep, for instance), so the author's intent is the
+          // better signal.
+          const IGNORED_SUBJECTS = [
+            /^v\d+\.\d+\.\d+/, // version commits made by `npm version`
+            /^chore\(release\)/, // version commits made by the release workflow
+            /^docs\(changelog\)/, // corrections to the changelog itself
+            /^Merge /, // merge commits
+          ]
+
+          function unreleasedCommits(tag) {
+            const range = tag ? `${tag}..HEAD` : 'HEAD'
+            const raw = sh(`git log --reverse --format=%s ${range}`)
+            if (!raw) {
+              return []
+            }
+            return raw.split('\n').filter(subject => !IGNORED_SUBJECTS.some(re => re.test(subject)))
+          }
+
+          function topSectionBullets(path) {
+            const lines = readFileSync(path, 'utf8').split('\n')
+            const start = lines.findIndex(l => l.startsWith('## '))
+            if (start === -1) {
+              return null
+            }
+            const rest = lines.slice(start + 1)
+            const end = rest.findIndex(l => l.startsWith('## '))
+            return (end === -1 ? rest : rest.slice(0, end))
+              .filter(l => l.startsWith('- '))
+              .map(l => l.slice(2).replace(/\s+\(@[^)]+\)\s*$/, '').trim())
+          }
+
+          const changelog = process.argv[2] ?? 'CHANGELOG.md'
+          let tag
+          try {
+            tag = sh('git describe --tags --abbrev=0')
+          } catch {
+            console.log('No tags found - nothing to compare against.')
+            process.exit(0)
+          }
+
+          const commits = unreleasedCommits(tag)
+          if (commits.length === 0) {
+            console.log(`No unreleased commits since ${tag}. Nothing to check.`)
+            process.exit(0)
+          }
+
+          const bullets = topSectionBullets(changelog)
+          if (bullets === null) {
+            console.error(`::error::${changelog} has no "## " section, but there are ${commits.length} unreleased commits since ${tag}.`)
+            process.exit(1)
+          }
+
+          const missing = commits.filter(c => !bullets.includes(c))
+          const extra = bullets.filter(b => !commits.includes(b))
+          const sameOrder = JSON.stringify(commits) === JSON.stringify(bullets)
+
+          if (missing.length === 0 && extra.length === 0 && sameOrder) {
+            console.log(`✓ ${changelog} matches all ${commits.length} unreleased commits since ${tag}.`)
+            process.exit(0)
+          }
+
+          console.error(`::error::${changelog} does not match the commits since ${tag}.`)
+          for (const m of missing) {
+            console.error(`  missing bullet for commit: ${m}`)
+          }
+          for (const e of extra) {
+            console.error(`  bullet with no matching commit: ${e}`)
+          }
+          if (!missing.length && !extra.length) {
+            console.error('  the bullets are all present but not in commit order')
+          }
+          console.error('\nExpected the top section to read:')
+          for (const c of commits) {
+            console.error(`  - ${c}`)
+          }
+          process.exit(1)
+          CHECK_CHANGELOG_EOF
+          node /tmp/check-changelog.mjs "$CHANGELOG_PATH"
 
   # Finish up the coverage reporting to Coveralls after all matrix steps of the build jobs have run
   collect_coverage_reports:

--- a/.github/workflows/nodejs-build-and-test.yml
+++ b/.github/workflows/nodejs-build-and-test.yml
@@ -112,7 +112,9 @@ jobs:
         env:
           CHANGELOG_PATH: ${{ inputs.changelog_path }}
         run: |
-          cat > /tmp/check-changelog.mjs <<'CHECK_CHANGELOG_EOF'
+          # Written to and read from RUNNER_TEMP rather than /tmp: on a Windows
+          # runner, bash's /tmp and node's /tmp are different directories.
+          cat > "$RUNNER_TEMP/check-changelog.mjs" <<'CHECK_CHANGELOG_EOF'
           import { execSync } from 'node:child_process'
           import { readFileSync } from 'node:fs'
           import process from 'node:process'
@@ -208,7 +210,7 @@ jobs:
           }
           process.exit(1)
           CHECK_CHANGELOG_EOF
-          node /tmp/check-changelog.mjs "$CHANGELOG_PATH"
+          node "$RUNNER_TEMP/check-changelog.mjs" "$CHANGELOG_PATH"
 
   # Finish up the coverage reporting to Coveralls after all matrix steps of the build jobs have run
   collect_coverage_reports:


### PR DESCRIPTION
Adds an **opt-in** check to `nodejs-build-and-test.yml` that verifies the changelog's top section lists every unreleased commit, in order, using the exact commit subjects.

**Off by default.** Not every repository that calls this workflow keeps its changelog that way — the two library repos in `homebridge-plugins` generate theirs at release time, for instance — so nothing changes for any existing caller unless it opts in.

## Usage

```yaml
build-and-test:
  uses: homebridge/.github/.github/workflows/nodejs-build-and-test.yml@latest
  with:
    check_changelog: true
```

`changelog_path` is also available, defaulting to `CHANGELOG.md`.

## Why

Changelog drift is only noticed at release time, which is the worst moment to find it. Two real cases from today, both of which this would have caught the moment they landed:

- A user-facing fan-speed fix, contributed via PR, was missing from `homebridge-govee`'s pending section entirely — it would have shipped with no changelog line and no credit to the contributor.
- Five commits were missing from `homebridge`'s pending section, three of them another contributor's.

## What it does

- Finds the most recent tag, and lists commit subjects since it.
- Reads the bullets from the first `## ` section of the changelog.
- Fails if any commit has no bullet, any bullet has no commit, or the order differs.

Trailing contributor credits (` (@user)`) are ignored when comparing, so crediting a contributor does not break the check.

Skipped, as they legitimately have no bullet of their own:

- version commits — `v1.2.3` and `chore(release): ...`
- `docs(changelog): ...`, which is how the changelog itself gets corrected
- merge commits

Reading the **first** `## ` section rather than looking for the literal text "Pending Release" matters: during a release the section gets dated before the tag exists, and keying off the wording would fail that commit.

⚠️ The job checks out with `fetch-depth: 0`, since tags are needed to work out what is unreleased.

## Testing

Run against all 21 `homebridge-plugins` repositories:

- 19 plugins pass.
- The 2 library repos fail, correctly — their changelogs are generated at release time and do not follow this convention. They will not opt in, which is the point of the flag.

I also extracted the script back out of the workflow's heredoc and re-ran it, to confirm it survives the indentation round-trip intact.
