### PR TITLE
fix(github): fall back to the workflow token when the optional secret is absent

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -24,4 +24,7 @@ jobs:
     steps:
       - uses: actions/labeler@v6
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          # Use the secret this workflow actually declares, falling back to
+          # the workflow's own token. Reading GITHUB_TOKEN directly meant a
+          # caller could pass `token` and have it silently ignored.
+          repo-token: ${{ secrets.token || github.token }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -32,7 +32,10 @@ jobs:
     steps:
       - uses: actions/stale@v10
         with:
-          repo-token: ${{ secrets.token }}
+          # The secret is optional, so fall back to the workflow's own
+          # token - passing an empty value overrides the action's default
+          # and the run fails to authenticate.
+          repo-token: ${{ secrets.token || github.token }}
           stale-issue-label: stale
           exempt-issue-labels: pinned,security,long running,discussion,vision,pending,verified,${{ inputs.exempt-issue-labels }}
           stale-issue-message: This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions.


### PR DESCRIPTION
Two reusable workflows mishandle their optional `token` secret. Split out of #48, where @Copilot spotted both — that PR is a version bump across 21 workflows, and token handling affects every repository in the org, so it deserves reviewing on its own terms.

Neither is introduced by #48; both predate it.

## `stale.yml`

```yaml
secrets:
  token:
    required: false
...
    repo-token: ${{ secrets.token }}
```

The secret is declared optional but passed unconditionally. A caller that omits it sends an **empty string**, which overrides the action's own default rather than falling back to it, and the run fails to authenticate. Callers that do pass a token have never seen this — which is why it has gone unnoticed.

## `labeler.yml`

```yaml
secrets:
  token:
    description: The GitHub Token which is used for the action bot
...
    repo-token: ${{ secrets.GITHUB_TOKEN }}
```

Declares a `token` secret that **nothing reads**. A caller can pass one and it is silently ignored. It works today only because it happens to read `GITHUB_TOKEN` directly, so the published interface is misleading rather than broken.

## The fix

Both now read the declared secret with a fallback to the workflow's own token:

```yaml
repo-token: ${{ secrets.token || github.token }}
```

Backwards compatible in both directions: a caller passing `token` gets what it passed, and one that does not gets the default it was already relying on.

## Audit of the rest

I checked every workflow in the repo that declares a `token` secret, rather than assuming these were the only two:

| Workflow | `required` | Reads | Status |
|---|---|---|---|
| `stale.yml` | false | `secrets.token` | fixed here |
| `labeler.yml` | false | `secrets.GITHUB_TOKEN` | fixed here |
| `pr-labeler.yml` | **true** | `secrets.token` | fine — always supplied |
| `release-drafter.yml` | **true** | `secrets.token` | fine — always supplied |
| `nodejs-build-and-test.yml` | false | both `secrets.github_token` and `secrets.token` | see below |

⚠️ **`nodejs-build-and-test.yml` has a third, milder instance.** Its two Coveralls steps disagree: `Coveralls Parallel` reads `secrets.github_token` while `Coveralls Finished` reads `secrets.token`. Only one of those is the declared secret. It is inert unless `enable_coverage` is on, so nothing is broken today.

I have deliberately left it out of this PR because #49 already modifies that file and the two would conflict. Happy to follow up once #49 lands, or fold it in here if you would rather see it merged first.
