### PR TITLE
fix(github): use the same coveralls token in both halves of the coverage run

### DIFF
--- a/.github/workflows/nodejs-build-and-test.yml
+++ b/.github/workflows/nodejs-build-and-test.yml
@@ -82,7 +82,10 @@ jobs:
         if: ${{ inputs.enable_coverage }}
         uses: coverallsapp/github-action@v2
         with:
-          github-token: ${{ secrets.github_token }}
+          # Use the secret this workflow actually declares, falling back to
+          # the workflow's own token. Reading GITHUB_TOKEN directly meant a
+          # caller could pass `token` and have it silently ignored.
+          github-token: ${{ secrets.token || github.token }}
           flag-name: run-${{ matrix.node_version }}
           parallel: true
 
@@ -240,5 +243,9 @@ jobs:
       - name: Coveralls Finished
         uses: coverallsapp/github-action@v2
         with:
-          github-token: ${{ secrets.token }}
+          # The secret is optional, so fall back to the workflow's own token.
+          # Without this, a caller that enables coverage but omits `token`
+          # uploads every report and then never closes the build off - each
+          # job goes green while Coveralls waits forever for the last one.
+          github-token: ${{ secrets.token || github.token }}
           parallel-finished: true


### PR DESCRIPTION
## The problem

Coveralls needs two halves to work across a Node matrix: each version uploads its own report with `parallel: true`, and one final job closes the build off with `parallel-finished: true`. Both need a token, and the two halves were reading different ones.

```yaml
# per-version upload
github-token: ${{ secrets.github_token }}

# the closing "all done" step
github-token: ${{ secrets.token }}
```

Only `token` is declared in the `secrets:` block. So the upload half read the run's automatic token and ignored anything the caller passed, while the closing half read only the caller's.

## Why nothing is broken today

Every repository that sets `enable_coverage: true` also happens to pass the token explicitly:

```yaml
    secrets:
      token: ${{ secrets.GITHUB_TOKEN }}
```

That is true of `homebridge`, `HAP-NodeJS`, `hap-client`, `homebridge-config-ui-x`, `bonjour` and `ciao` — all six. Both expressions therefore resolve to the same value, and `collect_coverage_reports` is passing on the most recent `homebridge` Node Build.

## Why it is still worth changing

It is a trap for the next caller. Enable coverage and forget the `secrets:` block, and:

- the uploads still succeed, falling back to the automatic token
- the closing step receives an **empty** token
- every job reports green, but the build is never closed off, so Coveralls waits indefinitely for a part that has already been sent

Silent, and the green ticks point away from the cause.

## The change

Both halves now read the same expression:

```yaml
github-token: ${{ secrets.token || github.token }}
```

This is the pattern already used in `stale.yml` and `labeler.yml` after #50, for the same reason. A caller that passes `token` has it honoured in both places — which it was not before, on the upload side. A caller that omits it gets the workflow's own token in both places, rather than one of each.

No behaviour changes for the six repositories above: they pass `secrets.GITHUB_TOKEN`, which is what the fallback resolves to anyway.
