### PR TITLE
fix(github): write package.json and package-lock.json with a trailing newline when bumping the version

### DIFF
--- a/.github/npm-version-script-esm.js
+++ b/.github/npm-version-script-esm.js
@@ -85,13 +85,16 @@ if (packageJSON.version !== publishTag) {
   console.warn(`Changing version in package.json from ${packageJSON.version} to ${publishTag}`)
 
   // save the package.json
+  // JSON.stringify does not end with a newline, but npm writes both of these
+  // files with one. Leaving it off makes the file fail an eol-last lint rule,
+  // which breaks any repo whose prepublishOnly lints the whole tree.
   packageJSON.version = publishTag
-  fs.writeFileSync('package.json', JSON.stringify(packageJSON, null, 2))
+  fs.writeFileSync('package.json', `${JSON.stringify(packageJSON, null, 2)}\n`)
 
   // perform the same change to the package-lock.json
   const packageLockJSON = JSON.parse(fs.readFileSync('package-lock.json', 'utf8'))
   packageLockJSON.version = publishTag
-  fs.writeFileSync('package-lock.json', JSON.stringify(packageLockJSON, null, 2))
+  fs.writeFileSync('package-lock.json', `${JSON.stringify(packageLockJSON, null, 2)}\n`)
 } else {
   console.warn(`Leaving version in package.json at ${packageJSON.version}`)
 }

--- a/.github/npm-version-script.js
+++ b/.github/npm-version-script.js
@@ -85,13 +85,16 @@ if (packageJSON.version !== publishTag) {
   console.warn(`Changing version in package.json from ${packageJSON.version} to ${publishTag}`)
 
   // save the package.json
+  // JSON.stringify does not end with a newline, but npm writes both of these
+  // files with one. Leaving it off makes the file fail an eol-last lint rule,
+  // which breaks any repo whose prepublishOnly lints the whole tree.
   packageJSON.version = publishTag
-  fs.writeFileSync('package.json', JSON.stringify(packageJSON, null, 2))
+  fs.writeFileSync('package.json', `${JSON.stringify(packageJSON, null, 2)}\n`)
 
   // perform the same change to the package-lock.json
   const packageLockJSON = JSON.parse(fs.readFileSync('package-lock.json', 'utf8'))
   packageLockJSON.version = publishTag
-  fs.writeFileSync('package-lock.json', JSON.stringify(packageLockJSON, null, 2))
+  fs.writeFileSync('package-lock.json', `${JSON.stringify(packageLockJSON, null, 2)}\n`)
 } else {
   console.warn(`Leaving version in package.json at ${packageJSON.version}`)
 }

--- a/.github/scripts/npm-version-script-auto.cjs
+++ b/.github/scripts/npm-version-script-auto.cjs
@@ -179,11 +179,14 @@ if (refArgument.includes('latest')) {
 if (packageJSON.version !== publishTag) {
 	console.warn(`Updating version in package.json from ${packageJSON.version} to ${publishTag}`)
 	packageJSON.version = publishTag
-	fs.writeFileSync('package.json', JSON.stringify(packageJSON, null, 2))
+	// JSON.stringify does not end with a newline, but npm writes both of these
+	// files with one. Leaving it off makes the file fail an eol-last lint rule,
+	// which breaks any repo whose prepublishOnly lints the whole tree.
+	fs.writeFileSync('package.json', `${JSON.stringify(packageJSON, null, 2)}\n`)
 
 	const packageLockJSON = JSON.parse(fs.readFileSync('package-lock.json', 'utf8'))
 	packageLockJSON.version = publishTag
-	fs.writeFileSync('package-lock.json', JSON.stringify(packageLockJSON, null, 2))
+	fs.writeFileSync('package-lock.json', `${JSON.stringify(packageLockJSON, null, 2)}\n`)
 } else {
 	console.warn(`Version in package.json is already ${packageJSON.version}`)
 }

--- a/.github/scripts/npm-version-script-esm-auto.js
+++ b/.github/scripts/npm-version-script-esm-auto.js
@@ -188,12 +188,15 @@ if (refArgument.includes('latest')) {
 if (packageJSON.version !== publishTag) {
 	console.warn(`Updating version in package.json from ${packageJSON.version} to ${publishTag}`)
 	packageJSON.version = publishTag
-	fs.writeFileSync('package.json', JSON.stringify(packageJSON, null, 2))
+	// JSON.stringify does not end with a newline, but npm writes both of these
+	// files with one. Leaving it off makes the file fail an eol-last lint rule,
+	// which breaks any repo whose prepublishOnly lints the whole tree.
+	fs.writeFileSync('package.json', `${JSON.stringify(packageJSON, null, 2)}\n`)
 
 	// perform the same change to the package-lock.json
 	const packageLockJSON = JSON.parse(fs.readFileSync('package-lock.json', 'utf8'))
 	packageLockJSON.version = publishTag
-	fs.writeFileSync('package-lock.json', JSON.stringify(packageLockJSON, null, 2))
+	fs.writeFileSync('package-lock.json', `${JSON.stringify(packageLockJSON, null, 2)}\n`)
 } else {
 	console.warn(`Version in package.json is already ${packageJSON.version}`)
 }


### PR DESCRIPTION
The release version-bump scripts write both manifests with `JSON.stringify`, which does not end with a newline. npm writes both files with one, so the file the workflow leaves behind differs from the file in the repo by a missing final newline.

That is enough to break a release. In a repo whose `prepublishOnly` runs lint over the whole tree, `eslint` reaches the rewritten `package.json` and fails:

```
package.json
  69:2  error  Newline required at end of file but not found  style/eol-last
✖ 1 problem (1 error, 0 warnings)
```

Both `august-yale` and `rainbird` failed this way on 2 August. Build, lint and the GitHub release step all passed and only `publish` failed, so no tag or release was created and nothing reached npm — the releases simply did not happen.

All four scripts that bump a version had it, so all four are fixed, for `package-lock.json` as well as `package.json`:

- `.github/npm-version-script-esm.js` — the one the current `release.yml` downloads and runs
- `.github/npm-version-script.js`
- `.github/scripts/npm-version-script-esm-auto.js`
- `.github/scripts/npm-version-script-auto.cjs`

Verified by running the patched scripts against a real checkout rather than by inspection: the version bumps exactly as before, both files come out ending in a newline and still parse as JSON, and the resulting `package.json` passes the same `eslint --max-warnings=0` that rejected it in CI.

Only repos that lint their whole tree during `prepublishOnly` were affected. The plugins keep their version in the repo and do not run these scripts on a stable release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)